### PR TITLE
Swap SHA256 for version of gaet with tbl2asn removed

### DIFF
--- a/inputs/image.yml
+++ b/inputs/image.yml
@@ -140,6 +140,6 @@
 - image_type: reference_assembly_evaluation
   name: bioboxes/gaet
   versions:
-    - sha256: e6f9d92208176f4f8125fda6e5aaa300e26acb3ea05bd49b96e79da3d8fa61b4
+    - sha256: b59cc7031b90a80b65671501a4bfdafded4e296f4c34789459d0ee2d40a0c323
       tasks: ["default"]
       name: "gaet-0.3.0-final mash-1.1.1 dpred-0.1.0"


### PR DESCRIPTION
The tbl2asn tool in the gaet biobox expires after one year. This has been removed from the gaet image. Update the SHA256 here, will have to hotfix the SHA256 in the nucleotides database.